### PR TITLE
Retract v1.2.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,7 @@
+module github.com/NaverCloudPlatform/ncloud-sdk-go-v2
+
+go 1.16
+
+require golang.org/x/net v0.0.0-20210614182718-04defd469f4e
+
+retract v1.2.0

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,7 @@
+golang.org/x/net v0.0.0-20210614182718-04defd469f4e h1:XpT3nA5TvE525Ne3hInMh6+GETgn27Zfm9dxsThnX2Q=
+golang.org/x/net v0.0.0-20210614182718-04defd469f4e/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
+golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
+golang.org/x/text v0.3.6/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
+golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=


### PR DESCRIPTION

안녕하세요

- 현재 GitHub repo에는 태그가 v1.1.7 까지 찍혀 있습니다. 
(https://github.com/NaverCloudPlatform/ncloud-sdk-go-v2/tags )
- 그런데 Go modules mirror 인 pkg.go.dev 에는 v1.2.0 이 존재합니다. 
(https://pkg.go.dev/github.com/NaverCloudPlatform/ncloud-sdk-go-v2?tab=versions )
- 이 때문에, 예를 들어 개발 환경에서 `go get github.com/NaverCloudPlatform/ncloud-sdk-go-v2` 명령을 실행하면
v1.1.7 을 다운로드 하는 것이 아니라 v1.2.0 을 다운로드 합니다.
- 이 PR은 `go.mod` 파일을 만들고, v1.2.0 을 retract 하는 라인을 추가하여
v1.2.0 을 retract 합니다. (Go modules mirror 인 pkg.go.dev 에 등록되어 있는 v1.2.0 을 retracted 로 변경)

[retract 예시]
- https://github.com/cloud-barista/cb-spider/blob/master/go.mod

```
retract (
	v0.3.12
	v0.3.11
)
```

- https://pkg.go.dev/github.com/cloud-barista/cb-spider?tab=versions

![image](https://user-images.githubusercontent.com/46767780/123392173-ba95da80-d5d7-11eb-8cf4-b492b6650176.png)

