### PR TITLE
Fix from *CloudRedisConfigGroupList to []*CloudRedisConfigGroup

### DIFF
--- a/services/vredis/delete_cloud_redis_config_group_response.go
+++ b/services/vredis/delete_cloud_redis_config_group_response.go
@@ -9,15 +9,14 @@
 package vredis
 
 type DeleteCloudRedisConfigGroupResponse struct {
+	RequestId *string `json:"requestId,omitempty"`
 
-RequestId *string `json:"requestId,omitempty"`
+	ReturnCode *string `json:"returnCode,omitempty"`
 
-ReturnCode *string `json:"returnCode,omitempty"`
+	ReturnMessage *string `json:"returnMessage,omitempty"`
 
-ReturnMessage *string `json:"returnMessage,omitempty"`
-
-TotalRows *int32 `json:"totalRows,omitempty"`
+	TotalRows *int32 `json:"totalRows,omitempty"`
 
 	// CloudRedisConfigGroup리스트
-CloudRedisConfigGroupList *CloudRedisConfigGroupList `json:"cloudRedisConfigGroupList,omitempty"`
+	CloudRedisConfigGroupList []*CloudRedisConfigGroup `json:"cloudRedisConfigGroupList,omitempty"`
 }


### PR DESCRIPTION
### Issue
- `deleteCloudRedisConfigGroup` API json 응답 unmarshal시 모델 필드가 잘못되어서 실패하는 현상
- `DeleteCloudRedisConfigGroupResponse` 모델 필드 수정
- refer : https://github.com/NaverCloudPlatform/terraform-provider-ncloud/issues/225