### PR TITLE
fix: remove 'omitempty' of sourcebuild project cmd

### DIFF
--- a/services/sourcebuild/project_cmd.go
+++ b/services/sourcebuild/project_cmd.go
@@ -9,11 +9,11 @@
 package sourcebuild
 
 type ProjectCmd struct {
-	Pre []*string `json:"pre,omitempty"`
+	Pre []*string `json:"pre"`
 
-	Build []*string `json:"build,omitempty"`
+	Build []*string `json:"build"`
 
-	Post []*string `json:"post,omitempty"`
+	Post []*string `json:"post"`
 
 	Dockerbuild *ProjectCmdDockerbuild `json:"dockerbuild,omitempty"`
 }


### PR DESCRIPTION
SourceBuild - Project 리소스의 cmd.pre/build/post 값을 empty array([])로 생성/수정하는 것을 허용하기 위해 'omitempty' 속성을 삭제합니다.