### PR TITLE
fix(vserver): revert breaking field type changes

### DIFF
--- a/services/vserver/access_control_group_rule.go
+++ b/services/vserver/access_control_group_rule.go
@@ -8,13 +8,24 @@
 
 package vserver
 
+type ProtocolType struct {
+	// 프로토콜 코드
+	Code *string `json:"code,omitempty"`
+
+	// 프로토콜 코드명
+	CodeName *string `json:"codeName,omitempty"`
+
+	// 프로토콜 번호
+	Number *int32 `json:"number,omitempty"`
+}
+
 type AccessControlGroupRule struct {
 
 	// ACG번호
 	AccessControlGroupNo *string `json:"accessControlGroupNo,omitempty"`
 
 	// 프로토콜유형
-	ProtocolType *CommonCode `json:"protocolType,omitempty"`
+	ProtocolType *ProtocolType `json:"protocolType,omitempty"`
 
 	// IP블록
 	IpBlock *string `json:"ipBlock,omitempty"`

--- a/services/vserver/block_storage_mapping.go
+++ b/services/vserver/block_storage_mapping.go
@@ -14,13 +14,13 @@ type BlockStorageMapping struct {
 	Order *int32 `json:"order,omitempty"`
 
 	// 블록스토리지스냅샷인스턴스번호
-	BlockStorageSnapshotInstanceNo *string `json:"blockStorageSnapshotInstanceNo,omitempty"`
+	BlockStorageSnapshotInstanceNo *int32 `json:"blockStorageSnapshotInstanceNo,omitempty"`
 
 	// 블록스토리지스냅샷이름
 	BlockStorageSnapshotName *string `json:"blockStorageSnapshotName,omitempty"`
 
 	// 블록스토리지사이즈
-	BlockStorageSize *float32 `json:"blockStorageSize,omitempty"`
+	BlockStorageSize *int64 `json:"blockStorageSize,omitempty"`
 
 	// 블록스토리지이름
 	BlockStorageName *string `json:"blockStorageName,omitempty"`
@@ -29,10 +29,10 @@ type BlockStorageMapping struct {
 	BlockStorageVolumeType *CommonCode `json:"blockStorageVolumeType,omitempty"`
 
 	// IOPS
-	Iops *float32 `json:"iops,omitempty"`
+	Iops *int32 `json:"iops,omitempty"`
 
 	// 부하처리성능
-	Throughput *float32 `json:"throughput,omitempty"`
+	Throughput *int64 `json:"throughput,omitempty"`
 
 	// 볼륨암호화여부
 	IsEncryptedVolume *bool `json:"isEncryptedVolume,omitempty"`

--- a/services/vserver/server_spec.go
+++ b/services/vserver/server_spec.go
@@ -20,7 +20,7 @@ type ServerSpec struct {
 	CpuCount *int32 `json:"cpuCount,omitempty"`
 
 	// 메모리사이즈
-	MemorySize *float32 `json:"memorySize,omitempty"`
+	MemorySize *int64 `json:"memorySize,omitempty"`
 
 	// 하이퍼바이저유형
 	HypervisorType *CommonCode `json:"hypervisorType,omitempty"`
@@ -38,7 +38,7 @@ type ServerSpec struct {
 	BlockStorageMaxThroughput *int32 `json:"blockStorageMaxThroughput,omitempty"`
 
 	// 네트워크성능
-	NetworkPerformance *int32 `json:"networkPerformance,omitempty"`
+	NetworkPerformance *int64 `json:"networkPerformance,omitempty"`
 
 	// 할당가능한네트워크인터페이스최대개수
 	NetworkInterfaceMaxCount *int32 `json:"networkInterfaceMaxCount,omitempty"`


### PR DESCRIPTION
## Overview

v1.6.28 changed several model field types in `services/vserver`, introducing
breaking changes that fail to compile against existing user code. This PR reverts
those types to the v1.6.26 baseline to restore backward compatibility.

Related: https://github.com/NaverCloudPlatform/ncloud-sdk-go-v2/commit/f8dc625b2747e76ac8087221cde3415b9669ab65

## Changes

### `access_control_group_rule.go`
- Re-added the `ProtocolType` type (`Code`, `CodeName`, `Number`)
- Reverted `AccessControlGroupRule.ProtocolType` field type: `*CommonCode` → `*ProtocolType`
  - `CommonCode` has no `Number` field, which broke `rule.ProtocolType.Number` access

### `block_storage_mapping.go`
| Field | Before (v1.6.28) | Restored (v1.6.26) |
|---|---|---|
| `BlockStorageSnapshotInstanceNo` | `*string` | `*int32` |
| `BlockStorageSize` | `*float32` | `*int64` |
| `Iops` | `*float32` | `*int32` |
| `Throughput` | `*float32` | `*int64` |

### `server_spec.go`
| Field | Before (v1.6.28) | Restored (v1.6.26) |
|---|---|---|
| `MemorySize` | `*float32` | `*int64` |
| `NetworkPerformance` | `*int32` | `*int64` |

> The newly added `ServerSpecNo *int64` field is additive (non-breaking) and was kept as-is.

## Impact

- Limited to the 3 model structs above in the `services/vserver` package
- No changes to API method (`V2Api.*`) signatures
- No impact on other packages such as `vnks`

## Verification

- [x] `go build ./services/vserver/` passes
- [x] Confirmed each file matches the v1.6.26 original via `diff` (server_spec matches except the additive field)