### PR TITLE
ci: fix goreleaser v2 release failure

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -38,9 +38,10 @@ jobs:
           PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
       -
         name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v2
+        uses: goreleaser/goreleaser-action@v6
         with:
-          version: latest
+          distribution: goreleaser
+          version: "~> v2"
           args: release
         env:
           GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,5 +1,6 @@
 # This is an example .goreleaser.yml file with some sensible defaults.
 # Make sure to check the documentation at https://goreleaser.com
+version: 2
 builds:
 - skip: true
 signs:
@@ -15,5 +16,5 @@ signs:
 release:
   draft: true
 changelog:
-  skip: true
+  disable: true
 


### PR DESCRIPTION
## Overview

The release workflow has been failing because GoReleaser v2 (pulled via `version: latest`)
requires the config file to declare `version: 2`, while our `.goreleaser.yaml` had no version
field (interpreted as version 0):

## Changes

### `.goreleaser.yaml`
- Added `version: 2` (fixes the failure above)
- Renamed `changelog.skip` → `changelog.disable` (`skip` was removed in v2; leaving it would
  fail the next validation step)

### `.github/workflows/go.yml`
- Bumped `goreleaser/goreleaser-action` from `@v2` to `@v6`
  - Resolves the Node 20 deprecation warning on the runner
  - Required for the semver-range `version` syntax below to be honored
- Added explicit `distribution: goreleaser`
- Pinned `version` from `latest` → `"~> v2"` so a future GoReleaser v3 release won't be
  auto-pulled and break the workflow again